### PR TITLE
Use enable_if instead of if statement in construct

### DIFF
--- a/any.hpp
+++ b/any.hpp
@@ -335,6 +335,20 @@ private:
     storage_union storage; // on offset(0) so no padding for align
     vtable_type*  vtable;
 
+    template<typename ValueType, typename T>
+    typename std::enable_if<requires_allocation<T>::value>::type
+    do_construct(ValueType&& value)
+    {
+        storage.dynamic = new T(std::forward<ValueType>(value));
+    }
+
+    template<typename ValueType, typename T>
+    typename std::enable_if<!requires_allocation<T>::value>::type
+    do_construct(ValueType&& value)
+    {
+        new (&storage.stack) T(std::forward<ValueType>(value));
+    }
+
     /// Chooses between stack and dynamic allocation for the type decay_t<ValueType>,
     /// assigns the correct vtable, and constructs the object on our storage.
     template<typename ValueType>
@@ -344,10 +358,7 @@ private:
 
         this->vtable = vtable_for_type<T>();
 
-        if(requires_allocation<T>::value)
-            storage.dynamic = new T(std::forward<ValueType>(value));
-        else
-            new (&storage.stack) T(std::forward<ValueType>(value));
+        do_construct<ValueType,T>(std::forward<ValueType>(value));
     }
 };
 


### PR DESCRIPTION
With an if statement GCC 6 generates a warning (-Wplacement-new). Fixes issue #4.

do_construct may be a slightly ugly name, but I couldn't immediately
find a better one.