### PR TITLE
Added any_cast_test, don't throw on failed pointer cast, equality operator

### DIFF
--- a/any.hpp
+++ b/any.hpp
@@ -381,19 +381,35 @@ namespace detail
 
 /// Performs *any_cast<add_const_t<remove_reference_t<ValueType>>>(&operand), or throws bad_any_cast on failure.
 template<typename ValueType>
-inline ValueType any_cast(const any& operand)
+inline ValueType any_cast(const any& operand, typename std::enable_if<!std::is_pointer<ValueType>::value>::type* = 0)
 {
     auto p = any_cast<typename std::add_const<typename std::remove_reference<ValueType>::type>::type>(&operand);
     if(p == nullptr) throw bad_any_cast();
     return *p;
 }
 
+template<typename ValueType>
+inline typename std::enable_if<std::is_pointer<ValueType>::value, ValueType>::type any_cast(const any& operand)
+{
+    auto p = any_cast<typename std::add_const<typename std::remove_reference<ValueType>::type>::type>(&operand);
+		if(p == nullptr) return nullptr;
+    return *p;
+}
+
 /// Performs *any_cast<remove_reference_t<ValueType>>(&operand), or throws bad_any_cast on failure.
 template<typename ValueType>
-inline ValueType any_cast(any& operand)
+inline ValueType any_cast(any& operand, typename std::enable_if<!std::is_pointer<ValueType>::value>::type* = 0)
 {
     auto p = any_cast<typename std::remove_reference<ValueType>::type>(&operand);
     if(p == nullptr) throw bad_any_cast();
+    return *p;
+}
+
+template<typename ValueType>
+inline typename std::enable_if<std::is_pointer<ValueType>::value, ValueType>::type any_cast(any& operand)
+{
+    auto p = any_cast<typename std::remove_reference<ValueType>::type>(&operand);
+		if(p == nullptr) return nullptr;
     return *p;
 }
 

--- a/any.hpp
+++ b/any.hpp
@@ -397,6 +397,30 @@ inline ValueType any_cast(any& operand)
     return *p;
 }
 
+template<typename ValueType>
+inline bool any_cast_test(const any& operand, ValueType const& result)
+{
+    auto p = any_cast<typename std::add_const<typename std::remove_reference<ValueType>::type>::type>(&operand);
+		if(p != nullptr) 
+		{
+			result = *p;
+			return true;
+		}
+    return false;
+}
+
+template<typename ValueType>
+inline bool any_cast_test(any& operand, ValueType& result)
+{
+    auto p = any_cast<typename std::remove_reference<ValueType>::type>(&operand);
+		if(p != nullptr) 
+		{
+			result = *p;
+			return true;
+		}
+    return false;
+}
+
 ///
 /// If ANY_IMPL_ANYCAST_MOVEABLE is not defined, does as N4562 specifies:
 ///     Performs *any_cast<remove_reference_t<ValueType>>(&operand), or throws bad_any_cast on failure.


### PR DESCRIPTION
I've added a few features to the class, I know these are not in the standard so I don't expect you to merge them into master but putting them here in case someone else needs them.

I think in most situations, if you're using **any** for storage, you don't know the type in advance so you want to *check* what type it is and exceptions are way too inconvenient (and slow), so I've added `any_cast_test` that returns a bool determining the success of the cast.

I've also adjusted `any_cast` to not throw an exception in case the type stored is a pointer (it returns nullptr instead).

Finally I've added an equality operator so you can test whether two different `any` instances contain the same data (either the same pointer or same value).