### PR TITLE
swap fixed for types that are not default constructible

### DIFF
--- a/any.hpp
+++ b/any.hpp
@@ -260,7 +260,10 @@ private: // Storage and Virtual Method Table
 
         static void swap(storage_union& lhs, storage_union& rhs) noexcept
         {
-            std::swap(reinterpret_cast<T&>(lhs.stack), reinterpret_cast<T&>(rhs.stack));
+            storage_union tmp_storage;
+            move(rhs, tmp_storage);
+            move(lhs, rhs);
+            move(tmp_storage, lhs);
         }
     };
 


### PR DESCRIPTION
This is a small fix in swap for types that are not default constructible (reference proxies for instance).

@SylvainCorlay