### PR TITLE
Used typeid to cast if RTTI is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,15 @@ project(any)
 cmake_minimum_required(VERSION 2.8)
 enable_testing()
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra")
+set(CMAKE_CXX_STANDARD 11)
+
+add_library(test_lib SHARED test_shared_lib.hpp test_shared_lib.cpp)
 
 add_executable(test_any test_any.cpp)
+target_link_libraries(test_any PRIVATE test_lib)
+target_compile_options(test_any PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra>
+)
+
 add_test(test_any test_any)

--- a/test_any.cpp
+++ b/test_any.cpp
@@ -1,6 +1,7 @@
 // Very simplist test, could be better.
 
 #include "any.hpp"
+#include "test_shared_lib.hpp"
 #include <memory>
 #include <string>
 #include <cstdlib>
@@ -280,5 +281,30 @@ int main()
         CHECK(except2 == false);
         CHECK(except3 == false);
 #endif
+    }
+
+    {
+      bool except1 = false, except2 = false;
+      auto big_any = shared_test_lib::createBigData();
+      auto small_any = shared_test_lib::createSmallData();
+      try {
+          any_cast<shared_test_lib::big_data>(big_any);
+      } catch (const bad_any_cast &) {
+          except1 = true;
+      }
+      try {
+          any_cast<shared_test_lib::small_data>(small_any);
+      } catch (const bad_any_cast &) {
+          except2 = true;
+      }
+
+#ifndef ANY_IMPL_NO_RTTI
+      CHECK(except1 == false);
+      CHECK(except2 == false);
+#else
+      CHECK(except1 == true);
+      CHECK(except2 == true);
+#endif
+
     }
 }

--- a/test_shared_lib.cpp
+++ b/test_shared_lib.cpp
@@ -1,0 +1,14 @@
+#include "test_shared_lib.hpp"
+
+namespace shared_test_lib {
+
+    big_data::big_data() : a(10), b(11), data() {}
+
+    small_data::small_data() : i(1) {}
+
+    linb::any createBigData() { return big_data{}; }
+
+    linb::any createSmallData() { return small_data{}; }
+
+}
+

--- a/test_shared_lib.hpp
+++ b/test_shared_lib.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "any.hpp"
+
+#ifdef WIN32
+#ifdef test_lib_EXPORTS
+#define TESTLIB_API __declspec(dllexport)
+#else
+#define TESTLIB_API __declspec(dllimport)
+#endif
+#else
+#define TESTLIB_API 
+#endif
+
+namespace shared_test_lib {
+struct TESTLIB_API big_data final {
+    explicit big_data();
+
+    double a;
+    float b;
+    int data[1024];
+};
+
+struct TESTLIB_API small_data final {
+    explicit small_data();
+    int i;
+};
+
+TESTLIB_API linb::any createBigData();
+TESTLIB_API linb::any createSmallData();
+
+} // namespace shared_test_lib


### PR DESCRIPTION
I added a shared library test to replicate the issue I was running into. It shows that you can pass an any across a shared lib boundry with RTTI enabled and that it fails if you do not.

Let me know if I took too much liberty with the cmake files / tests/ etc.

Fixes #13 